### PR TITLE
add mqtt to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,5 +29,8 @@
   },
   "engines": {
     "node": ">=10.0.0"
+  },
+  "dependencies": {
+    "mqtt": "^4.3.7"
   }
 }


### PR DESCRIPTION
The package.json doesn't include mqtt so in a clean node-red environment that may not already be importing mqtt for another node the mqtt nodes fail with an error